### PR TITLE
Flesh out the app path in /opt

### DIFF
--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -32,7 +32,7 @@ define backdrop::app (
         systempkgs => false,
         owner      => $user,
         group      => $group,
-        require    => File[$app_path],
+        require    => File["$app_path/shared"],
     }
     file { "$config_path/gunicorn":
         ensure  => present,

--- a/manifests/app.pp
+++ b/manifests/app.pp
@@ -9,14 +9,15 @@ define backdrop::app (
     include upstart
 
     $app_path = "/opt/${title}"
-    $virtualenv_path = "${app_path}/venv"
+    $virtualenv_path = "${app_path}/shared/venv"
     $log_path = "/var/log/${title}"
     $config_path = "/etc/gds/${title}"
 
-    file { ["$app_path", "$log_path", "$config_path"]:
-        ensure => directory,
-        owner  => $user,
-        group  => $group,
+    file { ["$log_path", "$config_path", "$app_path/releases", "$app_path/shared/log"]:
+        ensure  => directory,
+        owner   => $user,
+        group   => $group,
+        recurse => true,
     }
     nginx::vhost::proxy { "${title}-vhost":
         port          => 80,


### PR DESCRIPTION
Looks a little something like this:

```
/opt/<app-name>/shared/log   - I think this should link to /var/log/<app-name>
                      /venv  - Virtualenv directory
               /releases
```
